### PR TITLE
Return Success for successful commands

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,7 +3,11 @@
 This project is a vanilla TypeScript web application. Source files live in `src/` and are bundled with **esbuild** into `public/dist/`.
 
 - `src/` – TypeScript source files.
-- `src/api/` – API resource specifications shared with the front-end.
+- `src/api/` – API resource specifications and HTTP client. `apiClient.ts`
+  exposes `getLogs()` and `sendCommand()` which return either the expected
+  data or an array of `ApiError` objects. When a command succeeds it returns
+  a `{ success: true }` object defined in `src/api/success.ts`.
+- `src/services/` – application services mapping logical operations to API calls.
 - `public/` – static assets served by the dev server.
 - `public/dist/` – bundled JavaScript output from `esbuild`.
 - `public/index.html` – entry HTML file, references `dist/index.js`.
@@ -19,9 +23,13 @@ This project is a vanilla TypeScript web application. Source files live in `src/
 - No frameworks are used; code is plain TypeScript and DOM APIs.
 
 ### API resource specs
-- Files in `src/api/` define TypeScript interfaces mirroring backend C# records.
+- Files in `src/api/` define TypeScript interfaces mirroring backend C# records,
+  the `ApiError` structure used for failed operations, and a `Success` marker
+  response for endpoints without body data.
 - `LogMessage` maps to the server's `LogMessage` struct. Enum `LogLevel` is
   numeric (0 = Debug, 1 = Info, …).
+- All exported interfaces and enums in `src/api/` include documentation
+  comments for clarity.
 
 ## Development
 - Install dependencies with `npm install`.

--- a/src/api/apiClient.ts
+++ b/src/api/apiClient.ts
@@ -1,0 +1,59 @@
+import { LogMessage } from './logMessage';
+import { ApiError } from './error';
+import { Success } from './success';
+
+const API_BASE = 'http://localhost:5000';
+
+async function fetchApi<T>(path: string): Promise<T | ApiError[]> {
+  const resp = await fetch(`${API_BASE}${path}`);
+  const text = await resp.text();
+  if (!resp.ok) {
+    try {
+      return JSON.parse(text) as ApiError[];
+    } catch {
+      return [
+        {
+          message: text,
+          tags: [],
+          severity: 0,
+          args: [],
+          source: null,
+          exception: null,
+          originInformation: null,
+        },
+      ];
+    }
+  }
+  return JSON.parse(text) as T;
+}
+
+async function fetchApiVoid(path: string): Promise<Success | ApiError[]> {
+  const resp = await fetch(`${API_BASE}${path}`);
+  if (!resp.ok) {
+    const text = await resp.text();
+    try {
+      return JSON.parse(text) as ApiError[];
+    } catch {
+      return [
+        {
+          message: text,
+          tags: [],
+          severity: 0,
+          args: [],
+          source: null,
+          exception: null,
+          originInformation: null,
+        },
+      ];
+    }
+  }
+  return { success: true };
+}
+
+export async function getLogs(): Promise<LogMessage[] | ApiError[]> {
+  return fetchApi<LogMessage[]>('/logs');
+}
+
+export async function sendCommand(cmd: string): Promise<Success | ApiError[]> {
+  return fetchApiVoid(`/command/${encodeURIComponent(cmd)}`);
+}

--- a/src/api/error.ts
+++ b/src/api/error.ts
@@ -1,0 +1,21 @@
+/** Detailed error information returned by failed backend operations. */
+export interface ApiError {
+  /** Human readable message describing the failure. */
+  message: string;
+  /** Categorization tags provided by the server. */
+  tags: string[];
+  /** Numeric severity from the backend. */
+  severity: number;
+  /** Optional arguments giving extra context. */
+  args: unknown[];
+  /** Source or component that produced the error. */
+  source: string | null;
+  /** Optional exception details. */
+  exception: string | null;
+  /** Location in the server source code where the error originated. */
+  originInformation: {
+    filePath: string;
+    lineNumber: number;
+    linkString: string;
+  } | null;
+}

--- a/src/api/logMessage.ts
+++ b/src/api/logMessage.ts
@@ -1,3 +1,4 @@
+/** Severity level for log messages. Mirrors the server enum. */
 export enum LogLevel {
   Debug = 0,
   Info,
@@ -6,11 +7,18 @@ export enum LogLevel {
   Critical,
 }
 
+/** Log message entry returned by the backend API. */
 export interface LogMessage {
+  /** Severity level for the message. */
   level: LogLevel;
+  /** Text of the log entry. */
   message: string;
+  /** Optional file path associated with the event. */
   sourcePath?: string | null;
+  /** Optional line number associated with the event. */
   sourceLine?: number | null;
-  time: string; // ISO8601 string
+  /** Timestamp in ISO8601 format. */
+  time: string;
+  /** Arbitrary classification tags. */
   tags?: string[] | null;
 }

--- a/src/api/success.ts
+++ b/src/api/success.ts
@@ -1,0 +1,5 @@
+/** Marker response used when an operation succeeds without returning data. */
+export interface Success {
+  /** Always `true` to indicate success. */
+  success: true;
+}

--- a/src/services/commandService.ts
+++ b/src/services/commandService.ts
@@ -1,0 +1,19 @@
+import { sendCommand } from '../api/apiClient';
+import type { ApiError } from '../api/error';
+import type { Success } from '../api/success';
+
+/** Outcome of attempting to run a server command. */
+export interface CommandResult {
+  /** True if the command executed successfully. */
+  ok: boolean;
+  /** Errors returned from the API when not successful. */
+  errors?: ApiError[];
+}
+
+export async function runCommand(command: string): Promise<CommandResult> {
+  const result = await sendCommand(command);
+  if ((result as Success).success) {
+    return { ok: true };
+  }
+  return { ok: false, errors: result as ApiError[] };
+}

--- a/src/services/logService.ts
+++ b/src/services/logService.ts
@@ -1,0 +1,8 @@
+import { getLogs } from '../api/apiClient';
+import type { LogMessage } from '../api/logMessage';
+import type { ApiError } from '../api/error';
+
+/** Retrieve recent log messages from the backend. */
+export async function fetchLogs(): Promise<LogMessage[] | ApiError[]> {
+  return getLogs();
+}


### PR DESCRIPTION
## Summary
- note Success-based command handling in **AGENTS.md**
- define `Success` model for void responses
- update API client and command service to use Success

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6868d7ce57608324b70ccb810a6bc951