### PR TITLE
Add lint script and CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,21 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: oven-sh/setup-bun@v1
+        with:
+          bun-version: 'latest'
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+      - name: Run lint
+        run: bun run lint
+      - name: Run tests
+        run: bun run test

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,2 @@
+dist
+node_modules

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,0 +1,5 @@
+{
+  "plugins": ["prettier-plugin-svelte"],
+  "singleQuote": true,
+  "trailingComma": "all"
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # Repository Guidelines
 
-This repository hosts the Olve Trains application.  It includes the Svelte
+This repository hosts the Olve Trains application. It includes the Svelte
 front‑end located in `frontend/` and a minimal ASP.NET Core backend under
 `backend/`. All front-end commands should be executed from the repository root
 using **bun**. Run backend commands from the `backend/` directory using the
@@ -12,8 +12,12 @@ using **bun**. Run backend commands from the `backend/` directory using the
   details.
 - `backend/` – ASP.NET Core Minimal API server. See `backend/AGENTS.md`.
 - `dist/` – compiled JavaScript utilities.
-- `package.json` – scripts for dev, build and test. These reference
+- `package.json` – scripts for dev, build, lint and test. These reference
   configuration files under `frontend/` so run them from the repo root.
+- `.github/workflows/ci.yml` – GitHub Actions workflow that installs
+  dependencies with **bun**, runs `bun run lint` then `bun run test`.
+- `.prettierrc.json` – Prettier configuration used by the `lint` script.
+- `.prettierignore` – patterns of files ignored by Prettier.
 - `README.md` – project overview and quickstart instructions.
 
 Always update this `AGENTS.md` with repository changes so LLM agents can operate

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # Olve Trains
+
 [See AGENTS.md for repository guidelines.](./AGENTS.md)
 
 This repository hosts the Olve Trains application. It includes the Svelte +
@@ -8,7 +9,7 @@ TypeScript front‑end in `frontend/` and a minimal ASP.NET Core backend under
 ## Repository Layout
 
 - `frontend/` – Svelte front‑end UI (see `frontend/AGENTS.md` for details)
- - `backend/` – ASP.NET Core Minimal API server
+- `backend/` – ASP.NET Core Minimal API server
 - `dist/` – compiled JavaScript helpers
 
 ## Getting Started

--- a/bun.lock
+++ b/bun.lock
@@ -10,6 +10,8 @@
         "@testing-library/svelte": "^5.0.1",
         "jsdom": "^26.1.0",
         "msw": "^2.10.3",
+        "prettier": "3.6.2",
+        "prettier-plugin-svelte": "3.4.0",
         "svelte": "^4.2.7",
         "typescript": "^5.2.2",
         "vite": "^5.2.0",
@@ -343,6 +345,10 @@
     "picomatch": ["picomatch@4.0.2", "", {}, "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg=="],
 
     "postcss": ["postcss@8.5.6", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg=="],
+
+    "prettier": ["prettier@3.6.2", "", { "bin": { "prettier": "bin/prettier.cjs" } }, "sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ=="],
+
+    "prettier-plugin-svelte": ["prettier-plugin-svelte@3.4.0", "", { "peerDependencies": { "prettier": "^3.0.0", "svelte": "^3.2.0 || ^4.0.0-next.0 || ^5.0.0-next.0" } }, "sha512-pn1ra/0mPObzqoIQn/vUTR3ZZI6UuZ0sHqMK5x2jMLGrs53h0sXhkVuDcrlssHwIMk7FYrMjHBPoUSyyEEDlBQ=="],
 
     "pretty-format": ["pretty-format@27.5.1", "", { "dependencies": { "ansi-regex": "^5.0.1", "ansi-styles": "^5.0.0", "react-is": "^17.0.1" } }, "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ=="],
 

--- a/frontend/AGENTS.md
+++ b/frontend/AGENTS.md
@@ -15,12 +15,14 @@ All build scripts assume you run them from the repository root using **bun**.
 - `tsconfig.json` – TypeScript configuration with strict mode enabled.
 
 ## Coding style
+
 - Prefer modern ES6 syntax.
 - Use explicit types where possible.
 - Keep TypeScript `strict` mode enabled.
 - UI code uses Svelte components written in `.svelte` files.
 
 ### API resource specs
+
 - Files in `src/api/` define TypeScript interfaces mirroring backend C# records.
 - The `ApiError` structure describes failed operations.
 - A `Success` marker response is used for endpoints without body data.
@@ -28,11 +30,14 @@ All build scripts assume you run them from the repository root using **bun**.
 - All exported interfaces and enums in `src/api/` include documentation comments for clarity.
 
 ## Development
+
 - Install dependencies with `bun install` from the repository root.
 - Start the dev server with `bun run dev`.
 - Build once with `bun run build`.
+- Check formatting and basic lint rules with `bun run lint`.
 
 ## Testing
+
 - Tests are written with **Vitest** using the `jsdom` environment.
 - Mock Service Worker (MSW) intercepts `fetch` calls; handlers live in `tests/handlers.ts`.
 - Fixtures reside in `tests/fixtures/` and are loaded by MSW.

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,13 +1,13 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
-<head>
-  <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-  <title>Log Viewer</title>
-  <link rel="stylesheet" href="/style.css" />
-</head>
-<body>
-  <div id="app"></div>
-  <script type="module" src="/src/main.ts"></script>
-</body>
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Log Viewer</title>
+    <link rel="stylesheet" href="/style.css" />
+  </head>
+  <body>
+    <div id="app"></div>
+    <script type="module" src="/src/main.ts"></script>
+  </body>
 </html>

--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -1,13 +1,13 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
-<head>
-  <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-  <title>Log Viewer</title>
-  <link rel="stylesheet" href="/style.css" />
-</head>
-<body>
-  <div id="app"></div>
-  <script type="module" src="/src/main.ts"></script>
-</body>
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Log Viewer</title>
+    <link rel="stylesheet" href="/style.css" />
+  </head>
+  <body>
+    <div id="app"></div>
+    <script type="module" src="/src/main.ts"></script>
+  </body>
 </html>

--- a/frontend/public/style.css
+++ b/frontend/public/style.css
@@ -1,41 +1,54 @@
 .logs-container {
-    padding: 1rem;
-    background: #f9f9f9;
-    max-width: 800px;
-    margin: 1rem auto;
-    border-radius: 8px;
-    font-family: monospace;
-  }
-  
-.log-entry {
-margin-bottom: 0.5rem;
-white-space: pre-wrap;
+  padding: 1rem;
+  background: #f9f9f9;
+  max-width: 800px;
+  margin: 1rem auto;
+  border-radius: 8px;
+  font-family: monospace;
 }
 
-.log-debug    { color: #555; }
-.log-info     { color: #0a0; }
-.log-warning  { color: #e65c00; }
-.log-error    { color: #c00; }
-.log-critical { color: #900; }
+.log-entry {
+  margin-bottom: 0.5rem;
+  white-space: pre-wrap;
+}
 
-.log-error { /* for fetch/render errors */ color: #c00; font-weight: bold; }
+.log-debug {
+  color: #555;
+}
+.log-info {
+  color: #0a0;
+}
+.log-warning {
+  color: #e65c00;
+}
+.log-error {
+  color: #c00;
+}
+.log-critical {
+  color: #900;
+}
+
+.log-error {
+  /* for fetch/render errors */
+  color: #c00;
+  font-weight: bold;
+}
 
 .command-runner {
-    max-width: 800px;
-    margin: 1rem auto;
-    display: flex;
-    gap: .5rem;
-  }
-  #command-input {
-    flex: 1;
-    padding: .5rem;
-    font-family: monospace;
-  }
-  #command-send {
-    padding: .5rem 1rem;
-  }
-  .command-response {
-    margin-top: .5rem;
-    font-family: monospace;
-  }
-  
+  max-width: 800px;
+  margin: 1rem auto;
+  display: flex;
+  gap: 0.5rem;
+}
+#command-input {
+  flex: 1;
+  padding: 0.5rem;
+  font-family: monospace;
+}
+#command-send {
+  padding: 0.5rem 1rem;
+}
+.command-response {
+  margin-top: 0.5rem;
+  font-family: monospace;
+}

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -1,49 +1,49 @@
 <script lang="ts">
-import { onMount } from 'svelte';
-import { LogLevel } from './api/logMessage';
-import type { LogMessage } from './api/logMessage';
+  import { onMount } from 'svelte';
+  import { LogLevel } from './api/logMessage';
+  import type { LogMessage } from './api/logMessage';
 
-const API_BASE = 'http://localhost:5000';
-export let initialLogs: LogMessage[] = [];
-let logs: LogMessage[] = initialLogs;
-let command = '';
-let commandResponse = '';
+  const API_BASE = 'http://localhost:5000';
+  export let initialLogs: LogMessage[] = [];
+  let logs: LogMessage[] = initialLogs;
+  let command = '';
+  let commandResponse = '';
 
-function formatLog(log: LogMessage): string {
-  const timestamp = new Date(log.time).toISOString();
-  return `[${timestamp}] [${LogLevel[log.level]}]: ${log.message}`;
-}
-
-async function fetchLogs(): Promise<void> {
-  const resp = await fetch(`${API_BASE}/logs`);
-  if (!resp.ok) throw new Error(`Fetch logs failed: ${resp.status}`);
-  const data: any[] = await resp.json();
-  logs = data.map((item) => ({
-    level: item.level as LogLevel,
-    message: item.message as string,
-    sourcePath: item.sourcePath ?? null,
-    sourceLine: item.sourceLine ?? null,
-    time: item.time as string,
-    tags: item.tags ?? null,
-  }));
-}
-export { fetchLogs };
-
-async function runCommand(): Promise<void> {
-  const cmd = command.trim();
-  if (!cmd) return;
-  commandResponse = 'Running…';
-  const resp = await fetch(`${API_BASE}/command/${encodeURIComponent(cmd)}`);
-  commandResponse = resp.ok
-    ? `✅ Command "${cmd}" succeeded`
-    : `❌ Command "${cmd}" failed (${resp.status})`;
-  if (resp.ok) {
-    command = '';
-    await fetchLogs();
+  function formatLog(log: LogMessage): string {
+    const timestamp = new Date(log.time).toISOString();
+    return `[${timestamp}] [${LogLevel[log.level]}]: ${log.message}`;
   }
-}
 
-onMount(fetchLogs);
+  async function fetchLogs(): Promise<void> {
+    const resp = await fetch(`${API_BASE}/logs`);
+    if (!resp.ok) throw new Error(`Fetch logs failed: ${resp.status}`);
+    const data: any[] = await resp.json();
+    logs = data.map((item) => ({
+      level: item.level as LogLevel,
+      message: item.message as string,
+      sourcePath: item.sourcePath ?? null,
+      sourceLine: item.sourceLine ?? null,
+      time: item.time as string,
+      tags: item.tags ?? null,
+    }));
+  }
+  export { fetchLogs };
+
+  async function runCommand(): Promise<void> {
+    const cmd = command.trim();
+    if (!cmd) return;
+    commandResponse = 'Running…';
+    const resp = await fetch(`${API_BASE}/command/${encodeURIComponent(cmd)}`);
+    commandResponse = resp.ok
+      ? `✅ Command "${cmd}" succeeded`
+      : `❌ Command "${cmd}" failed (${resp.status})`;
+    if (resp.ok) {
+      command = '';
+      await fetchLogs();
+    }
+  }
+
+  onMount(fetchLogs);
 </script>
 
 <header>

--- a/frontend/src/app.ts
+++ b/frontend/src/app.ts
@@ -37,7 +37,7 @@ async function renderLogs(): Promise<void> {
   container.innerHTML = '<h2>Server Logs</h2>';
   try {
     const logs = await fetchLogMessages();
-    logs.forEach(log => {
+    logs.forEach((log) => {
       const entry = document.createElement('div');
       entry.className = `log-entry log-${LogLevel[log.level]}`;
       entry.textContent = formatLog(log);
@@ -51,7 +51,9 @@ async function renderLogs(): Promise<void> {
   }
 }
 
-async function runCommand(command: string): Promise<{ ok: boolean; message: string }> {
+async function runCommand(
+  command: string,
+): Promise<{ ok: boolean; message: string }> {
   const result = await executeCommand(command);
   if (result.ok) {
     return {
@@ -59,7 +61,7 @@ async function runCommand(command: string): Promise<{ ok: boolean; message: stri
       message: `✅ Command "${command}" succeeded`,
     };
   }
-  const errMsg = result.errors!.map(e => e.message).join('; ');
+  const errMsg = result.errors!.map((e) => e.message).join('; ');
   return {
     ok: false,
     message: `❌ Command "${command}" failed: ${errMsg}`,
@@ -90,7 +92,7 @@ function setupCommandRunner(): void {
     }
   });
 
-  input.addEventListener('keydown', e => {
+  input.addEventListener('keydown', (e) => {
     if (e.key === 'Enter') {
       e.preventDefault();
       button.click();

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -11,10 +11,5 @@
     "types": ["svelte"],
     "moduleResolution": "node"
   },
-  "include": [
-    "src/**/*",
-    "src/**/*.svelte",
-    "vite.config.ts",
-    "vite-env.d.ts"
-  ]
+  "include": ["src/**/*", "src/**/*.svelte", "vite.config.ts", "vite-env.d.ts"]
 }

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,6 +1,6 @@
 // vite.config.ts
 import { defineConfig } from 'vite';
-import { svelte }    from '@sveltejs/vite-plugin-svelte';
+import { svelte } from '@sveltejs/vite-plugin-svelte';
 import { fileURLToPath } from 'url';
 import { dirname } from 'path';
 

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -3,7 +3,10 @@ import { svelte } from '@sveltejs/vite-plugin-svelte';
 import { fileURLToPath } from 'url';
 import { dirname, resolve } from 'path';
 
-const configPath = resolve(dirname(fileURLToPath(import.meta.url)), 'svelte.config.js');
+const configPath = resolve(
+  dirname(fileURLToPath(import.meta.url)),
+  'svelte.config.js',
+);
 
 export default defineConfig({
   plugins: [svelte({ configFile: configPath })],

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
     "dev": "vite --config frontend/vite.config.ts",
     "build": "vite build --config frontend/vite.config.ts",
     "preview": "vite preview --config frontend/vite.config.ts",
-    "test": "vitest run --config frontend/vitest.config.ts"
+    "test": "vitest run --config frontend/vitest.config.ts",
+    "lint": "prettier --check ."
   },
   "devDependencies": {
     "@testing-library/dom": "^10.4.0",
@@ -14,6 +15,8 @@
     "@sveltejs/vite-plugin-svelte": "^3.0.0",
     "jsdom": "^26.1.0",
     "msw": "^2.10.3",
+    "prettier": "3.6.2",
+    "prettier-plugin-svelte": "3.4.0",
     "typescript": "^5.2.2",
     "vite": "^5.2.0",
     "svelte": "^4.2.7",


### PR DESCRIPTION
## Summary
- add a Prettier-based lint script and config
- run lint and tests in new GitHub Actions workflow
- document lint and workflow in AGENTS guidelines
- format repo with Prettier so lint passes

## Testing
- `bun run lint`
- `bun run test`


------
https://chatgpt.com/codex/tasks/task_e_6868eba1e7808324837cc47776a77731