### PR TITLE
Add repo-wide lint script

### DIFF
--- a/.biomeignore
+++ b/.biomeignore
@@ -1,0 +1,5 @@
+# Ignore build outputs and dependencies
+node_modules
+frontend/public/dist
+backend/bin
+backend/obj

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,9 +13,11 @@ using **bun**. Run backend commands from the `backend/` directory using the
 - `backend/` – ASP.NET Core Minimal API server. See `backend/AGENTS.md`.
 - `backend/setup-dotnet.sh` – script to install the .NET SDK and pre-restore
   backend packages for offline use.
-- `package.json` – scripts for dev, build and test. These reference
+- `package.json` – scripts for dev, build, lint and test. These reference
   configuration files under `frontend/` so run them from the repo root.
 - `README.md` – project overview and quickstart instructions.
-
-Always update this `AGENTS.md` with repository changes so LLM agents can operate
-correctly.
+## Linting
+- Run `bun run lint` to check formatting and style across the repo.
+  It lints frontend and configuration files via **biome** and verifies C#
+  code with `dotnet format`.
+Always update this `AGENTS.md` with repository changes so LLM agents can operate correctly.

--- a/backend/AGENTS.md
+++ b/backend/AGENTS.md
@@ -14,5 +14,6 @@ dotnet run
 
 - The API exposes a single endpoint `GET /ping` that returns `"pong"`.
 - All C# files use `nullable` reference types and implicit usings.
+- Run `bun run lint` to verify formatting with `dotnet format`.
 
 Keep this file updated with any server changes.

--- a/biome.json
+++ b/biome.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://biomejs.dev/schemas/v1.json",
+  "formatter": {
+    "enabled": true
+  },
+  "linter": {
+    "enabled": true
+  }
+}

--- a/bun.lock
+++ b/bun.lock
@@ -4,6 +4,7 @@
     "": {
       "name": "olve-trains-ui",
       "devDependencies": {
+        "@biomejs/biome": "^2.0.6",
         "@sveltejs/vite-plugin-svelte": "^3.0.0",
         "@testing-library/dom": "^10.4.0",
         "@testing-library/jest-dom": "^6.6.3",
@@ -29,6 +30,24 @@
     "@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.27.1", "", {}, "sha512-D2hP9eA+Sqx1kBZgzxZh0y1trbuU+JoDkiEwqhQ36nodYqJwyEIhPSdMNd7lOm/4io72luTPWH20Yda0xOuUow=="],
 
     "@babel/runtime": ["@babel/runtime@7.27.6", "", {}, "sha512-vbavdySgbTTrmFE+EsiqUTzlOr5bzlnJtUv9PynGCAKvfQqjIXbvFdumPM/GxMDfyuGMJaJAU6TO4zc1Jf1i8Q=="],
+
+    "@biomejs/biome": ["@biomejs/biome@2.0.6", "", { "optionalDependencies": { "@biomejs/cli-darwin-arm64": "2.0.6", "@biomejs/cli-darwin-x64": "2.0.6", "@biomejs/cli-linux-arm64": "2.0.6", "@biomejs/cli-linux-arm64-musl": "2.0.6", "@biomejs/cli-linux-x64": "2.0.6", "@biomejs/cli-linux-x64-musl": "2.0.6", "@biomejs/cli-win32-arm64": "2.0.6", "@biomejs/cli-win32-x64": "2.0.6" }, "bin": { "biome": "bin/biome" } }, "sha512-RRP+9cdh5qwe2t0gORwXaa27oTOiQRQvrFf49x2PA1tnpsyU7FIHX4ZOFMtBC4QNtyWsN7Dqkf5EDbg4X+9iqA=="],
+
+    "@biomejs/cli-darwin-arm64": ["@biomejs/cli-darwin-arm64@2.0.6", "", { "os": "darwin", "cpu": "arm64" }, "sha512-AzdiNNjNzsE6LfqWyBvcL29uWoIuZUkndu+wwlXW13EKcBHbbKjNQEZIJKYDc6IL+p7bmWGx3v9ZtcRyIoIz5A=="],
+
+    "@biomejs/cli-darwin-x64": ["@biomejs/cli-darwin-x64@2.0.6", "", { "os": "darwin", "cpu": "x64" }, "sha512-wJjjP4E7bO4WJmiQaLnsdXMa516dbtC6542qeRkyJg0MqMXP0fvs4gdsHhZ7p9XWTAmGIjZHFKXdsjBvKGIJJQ=="],
+
+    "@biomejs/cli-linux-arm64": ["@biomejs/cli-linux-arm64@2.0.6", "", { "os": "linux", "cpu": "arm64" }, "sha512-ZSVf6TYo5rNMUHIW1tww+rs/krol7U5A1Is/yzWyHVZguuB0lBnIodqyFuwCNqG9aJGyk7xIMS8HG0qGUPz0SA=="],
+
+    "@biomejs/cli-linux-arm64-musl": ["@biomejs/cli-linux-arm64-musl@2.0.6", "", { "os": "linux", "cpu": "arm64" }, "sha512-CVPEMlin3bW49sBqLBg2x016Pws7eUXA27XYDFlEtponD0luYjg2zQaMJ2nOqlkKG9fqzzkamdYxHdMDc2gZFw=="],
+
+    "@biomejs/cli-linux-x64": ["@biomejs/cli-linux-x64@2.0.6", "", { "os": "linux", "cpu": "x64" }, "sha512-geM1MkHTV1Kh2Cs/Xzot9BOF3WBacihw6bkEmxkz4nSga8B9/hWy5BDiOG3gHDGIBa8WxT0nzsJs2f/hPqQIQw=="],
+
+    "@biomejs/cli-linux-x64-musl": ["@biomejs/cli-linux-x64-musl@2.0.6", "", { "os": "linux", "cpu": "x64" }, "sha512-mKHE/e954hR/hSnAcJSjkf4xGqZc/53Kh39HVW1EgO5iFi0JutTN07TSjEMg616julRtfSNJi0KNyxvc30Y4rQ=="],
+
+    "@biomejs/cli-win32-arm64": ["@biomejs/cli-win32-arm64@2.0.6", "", { "os": "win32", "cpu": "arm64" }, "sha512-290V4oSFoKaprKE1zkYVsDfAdn0An5DowZ+GIABgjoq1ndhvNxkJcpxPsiYtT7slbVe3xmlT0ncdfOsN7KruzA=="],
+
+    "@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@2.0.6", "", { "os": "win32", "cpu": "x64" }, "sha512-bfM1Bce0d69Ao7pjTjUS+AWSZ02+5UHdiAP85Th8e9yV5xzw6JrHXbL5YWlcEKQ84FIZMdDc7ncuti1wd2sdbw=="],
 
     "@bundled-es-modules/cookie": ["@bundled-es-modules/cookie@2.0.1", "", { "dependencies": { "cookie": "^0.7.2" } }, "sha512-8o+5fRPLNbjbdGRRmJj3h6Hh1AQJf2dk3qQ/5ZFb+PXkRNiSoMGGUKlsgLfrxneb72axVJyIYji64E2+nNfYyw=="],
 

--- a/frontend/AGENTS.md
+++ b/frontend/AGENTS.md
@@ -31,6 +31,7 @@ All build scripts assume you run them from the repository root using **bun**.
 - Install dependencies with `bun install` from the repository root.
 - Start the dev server with `bun run dev`.
 - Build once with `bun run build`.
+- Run `bun run lint` to lint front-end sources and config files via **Biome**.
 
 ## Testing
 - Tests are written with **Vitest** using the `jsdom` environment.

--- a/package.json
+++ b/package.json
@@ -5,18 +5,20 @@
     "dev": "vite --config frontend/vite.config.ts",
     "build": "vite build --config frontend/vite.config.ts",
     "preview": "vite preview --config frontend/vite.config.ts",
-    "test": "vitest run --config frontend/vitest.config.ts"
+    "test": "vitest run --config frontend/vitest.config.ts",
+    "lint": "biome lint . --reporter json && cd backend && dotnet format --verify-no-changes"
   },
   "devDependencies": {
+    "@biomejs/biome": "^2.0.6",
+    "@sveltejs/vite-plugin-svelte": "^3.0.0",
     "@testing-library/dom": "^10.4.0",
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/svelte": "^5.0.1",
-    "@sveltejs/vite-plugin-svelte": "^3.0.0",
     "jsdom": "^26.1.0",
     "msw": "^2.10.3",
+    "svelte": "^4.2.7",
     "typescript": "^5.2.2",
     "vite": "^5.2.0",
-    "svelte": "^4.2.7",
     "vitest": "^3.2.4"
   },
   "type": "module"


### PR DESCRIPTION
## Summary
- add Biome config and ignore files
- add `lint` script in package.json that runs Biome and dotnet format
- document lint usage in AGENTS guides

## Testing
- `bun run lint`
- `bun run test`


------
https://chatgpt.com/codex/tasks/task_e_68691e58b8b88324ac376c2304ed7252