### PR TITLE
Add CI workflow for lint and tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,21 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+      - uses: actions/setup-dotnet@v3
+        with:
+          dotnet-version: '9.0.x'
+      - run: bun install --frozen-lockfile
+      - run: bun run lint
+      - run: bun run test

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,6 +16,8 @@ using **bun**. Run backend commands from the `backend/` directory using the
 - `package.json` – scripts for dev, build, lint and test. These reference
   configuration files under `frontend/` so run them from the repo root.
 - `README.md` – project overview and quickstart instructions.
+- `.github/workflows/ci.yml` – GitHub Actions workflow that runs `bun run lint`
+  and `bun run test` on every push and pull request.
 ## Linting
 - Run `bun run lint` to check formatting and style across the repo.
   It lints frontend and configuration files via **biome** and verifies C#


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow that installs bun and dotnet
- run `bun run lint` and `bun run test` in CI
- document the workflow in `AGENTS.md`

## Testing
- `bun run lint`
- `bun run test`


------
https://chatgpt.com/codex/tasks/task_e_6869207cf3e083249d75e844a6ec6655