### PR TITLE
Add API spec generation script

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,8 +13,11 @@ using **bun**. Run backend commands from the `backend/` directory using the
 - `backend/` – ASP.NET Core Minimal API server. See `backend/AGENTS.md`.
 - `backend/setup-dotnet.sh` – script to install the .NET SDK and pre-restore
   backend packages for offline use.
-- `package.json` – scripts for dev, build, lint and test. These reference
+- `package.json` – scripts for dev, build, lint, test and API spec generation.
+  Run `bun run apigen` to regenerate `api/api-spec.json`.
+  These scripts reference
   configuration files under `frontend/` so run them from the repo root.
+- `api/` – generated OpenAPI specification for the backend.
 - `README.md` – project overview and quickstart instructions.
 ## Linting
 - Run `bun run lint` to check formatting and style across the repo.

--- a/api/api-spec.json
+++ b/api/api-spec.json
@@ -1,0 +1,34 @@
+{
+  "openapi": "3.0.1",
+  "info": {
+    "title": "backend | v1",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/ping": {
+      "get": {
+        "tags": [
+          "backend"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": { },
+  "tags": [
+    {
+      "name": "backend"
+    }
+  ]
+}

--- a/backend/AGENTS.md
+++ b/backend/AGENTS.md
@@ -15,5 +15,7 @@ dotnet run
 - The API exposes a single endpoint `GET /ping` that returns `"pong"`.
 - All C# files use `nullable` reference types and implicit usings.
 - Run `bun run lint` to verify formatting with `dotnet format`.
+- Generate the OpenAPI spec with `bun run apigen`. This writes
+  `api/api-spec.json` at the repository root.
 
 Keep this file updated with any server changes.

--- a/backend/Program.cs
+++ b/backend/Program.cs
@@ -3,8 +3,10 @@ using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Hosting;
 
 var builder = WebApplication.CreateBuilder(args);
+builder.Services.AddEndpointsApiExplorer();
+builder.Services.AddOpenApi();
 var app = builder.Build();
 
-app.MapGet("/ping", () => "pong");
+app.MapGet("/ping", () => "pong").WithOpenApi();
 
 app.Run();

--- a/backend/backend.csproj
+++ b/backend/backend.csproj
@@ -3,5 +3,13 @@
     <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+    <!-- Directory where OpenAPI specs are written when generation is triggered -->
+    <OpenApiDocumentsDirectory>$(MSBuildProjectDirectory)/../api</OpenApiDocumentsDirectory>
+    <!-- Filename for generated specs when enabled -->
+    <OpenApiGenerateDocumentsOptions>--file-name api-spec</OpenApiGenerateDocumentsOptions>
   </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.ApiDescription.Server" Version="9.*" />
+    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.*" />
+  </ItemGroup>
 </Project>

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "build": "vite build --config frontend/vite.config.ts",
     "preview": "vite preview --config frontend/vite.config.ts",
     "test": "vitest run --config frontend/vitest.config.ts",
-    "lint": "biome lint . --reporter json && cd backend && dotnet format --verify-no-changes"
+    "lint": "biome lint . --reporter json && cd backend && dotnet format --verify-no-changes",
+    "apigen": "dotnet build backend/backend.csproj -p:OpenApiGenerateDocuments=true"
   },
   "devDependencies": {
     "@biomejs/biome": "^2.0.6",


### PR DESCRIPTION
## Summary
- enable OpenAPI spec generation for the backend
- output generated spec under the new `api/` folder
- expose `bun run apigen` script
- document new workflow in AGENTS

## Testing
- `bun run apigen`
- `bun run lint`
- `bun run test`


------
https://chatgpt.com/codex/tasks/task_e_686921efa1b08324a9a139eb0bec0e2c