### PR TITLE
Add setup-bun.sh for installing Bun

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,6 +13,8 @@ using **bun**. Run backend commands from the `backend/` directory using the
 - `backend/` – ASP.NET Core Minimal API server. See `backend/AGENTS.md`.
 - `backend/setup-dotnet.sh` – script to install the .NET SDK and pre-restore
   backend packages for offline use.
+- `setup-bun.sh` – script at the repository root that installs Bun and runs
+  `bun install` to fetch front-end dependencies.
 - `install-act.sh` – helper to install Docker (if missing) and the `act` CLI
   for running GitHub Actions workflows locally.
 - `package.json` – scripts for dev, build, lint, test and API spec generation.

--- a/frontend/AGENTS.md
+++ b/frontend/AGENTS.md
@@ -28,10 +28,11 @@ All build scripts assume you run them from the repository root using **bun**.
 - All exported interfaces and enums in `src/api/` include documentation comments for clarity.
 
 ## Development
-- Install dependencies with `bun install` from the repository root.
-- Start the dev server with `bun run dev`.
-- Build once with `bun run build`.
-- Run `bun run lint` to lint front-end sources and config files via **Biome**.
+ - Install dependencies with `bun install` from the repository root or run
+   `./setup-bun.sh` to install Bun and install packages in one step.
+ - Start the dev server with `bun run dev`.
+ - Build once with `bun run build`.
+ - Run `bun run lint` to lint front-end sources and config files via **Biome**.
 
 ## Testing
 - Tests are written with **Vitest** using the `jsdom` environment.

--- a/setup-bun.sh
+++ b/setup-bun.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# -----------------------------------------------------------------------------
+# setup-bun.sh
+#
+# Installs Bun if it is not already available and installs repository
+# dependencies using `bun install`.
+# -----------------------------------------------------------------------------
+
+if ! command -v bun >/dev/null 2>&1; then
+  echo "Bun not found. Installing..."
+  curl -fsSL https://bun.sh/install | bash
+  export PATH="$HOME/.bun/bin:$PATH"
+fi
+
+# Run bun install from the repository root (directory of this script)
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$SCRIPT_DIR"
+
+bun install
+
+echo "✅ Bun setup complete."


### PR DESCRIPTION
## Summary
- add `setup-bun.sh` script to install Bun and run `bun install`
- document new script in `AGENTS.md`
- mention the script in `frontend/AGENTS.md`

## Testing
- `bun run lint`
- `bun run test`

------
https://chatgpt.com/codex/tasks/task_e_686929019428832482f6b13122c2d65f