### PR TITLE
Move setup scripts to dedicated folder

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,12 +11,13 @@ using **bun**. Run backend commands from the `backend/` directory using the
 - `frontend/` – current Svelte + TypeScript UI. See `frontend/AGENTS.md` for all
   details.
 - `backend/` – ASP.NET Core Minimal API server. See `backend/AGENTS.md`.
-- `backend/setup-dotnet.sh` – script to install the .NET SDK and pre-restore
-  backend packages for offline use.
-- `setup-bun.sh` – script at the repository root that installs Bun and runs
-  `bun install` to fetch front-end dependencies.
-- `install-act.sh` – helper to install Docker (if missing) and the `act` CLI
-  for running GitHub Actions workflows locally.
+- `scripts/` – helper scripts for preparing a development environment:
+  - `setup-bun.sh` installs Bun and runs `bun install`.
+  - `setup-dotnet.sh` installs the .NET SDK and pre-restores backend packages.
+  - `install-act.sh` installs Docker (if missing) and the `act` CLI for running
+    GitHub Actions locally.
+  - `setup-agent.sh` runs the above scripts and then sets the `AGENT_SETUP`
+    environment variable.
 - `package.json` – scripts for dev, build, lint, test and API spec generation.
   Run `bun run apigen` to regenerate `api/api-spec.json`.
   These scripts reference

--- a/README.md
+++ b/README.md
@@ -53,10 +53,10 @@ Integration tests will be introduced alongside the backend as it evolves.
 ## Running GitHub Actions locally
 
 To test workflows defined under `.github/workflows/` without pushing code, use
-the `install-act.sh` script:
+the `scripts/install-act.sh` script:
 
 ```bash
-sudo ./install-act.sh
+sudo ./scripts/install-act.sh
 ```
 
 This installs Docker (if necessary) and the [`act` CLI](https://github.com/nektos/act)

--- a/backend/AGENTS.md
+++ b/backend/AGENTS.md
@@ -3,8 +3,9 @@
 This directory hosts the ASP.NET Core Minimal API.
 
 - Built with .NET 9 using `Microsoft.NET.Sdk.Web`.
-- `setup-dotnet.sh` installs the required .NET SDK and pre-restores packages for
-  offline development. Run it once with network access.
+- `../scripts/setup-dotnet.sh` installs the required .NET SDK and pre-restores
+  packages for offline development. Run it once with network access from the
+  repository root.
 - To run locally:
 
 ```bash

--- a/frontend/AGENTS.md
+++ b/frontend/AGENTS.md
@@ -29,7 +29,7 @@ All build scripts assume you run them from the repository root using **bun**.
 
 ## Development
  - Install dependencies with `bun install` from the repository root or run
-   `./setup-bun.sh` to install Bun and install packages in one step.
+   `./scripts/setup-bun.sh` to install Bun and install packages in one step.
  - Start the dev server with `bun run dev`.
  - Build once with `bun run build`.
  - Run `bun run lint` to lint front-end sources and config files via **Biome**.

--- a/scripts/install-act.sh
+++ b/scripts/install-act.sh
@@ -1,6 +1,11 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+if [[ -n "${AGENT_SETUP:-}" ]]; then
+  echo "AGENT_SETUP is set. These scripts are only for setting up the agent." >&2
+  exit 1
+fi
+
 # -----------------------------------------------------------------------------
 # install-act.sh
 #

--- a/scripts/setup-agent.sh
+++ b/scripts/setup-agent.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ -n "${AGENT_SETUP:-}" ]]; then
+  echo "AGENT_SETUP is set. These scripts are only for setting up the agent." >&2
+  exit 1
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+"$SCRIPT_DIR/setup-bun.sh"
+"$SCRIPT_DIR/setup-dotnet.sh"
+"$SCRIPT_DIR/install-act.sh"
+
+export AGENT_SETUP=1
+
+echo "Agent setup complete. AGENT_SETUP variable set."

--- a/scripts/setup-bun.sh
+++ b/scripts/setup-bun.sh
@@ -1,6 +1,11 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+if [[ -n "${AGENT_SETUP:-}" ]]; then
+  echo "AGENT_SETUP is set. These scripts are only for setting up the agent." >&2
+  exit 1
+fi
+
 # -----------------------------------------------------------------------------
 # setup-bun.sh
 #

--- a/scripts/setup-dotnet.sh
+++ b/scripts/setup-dotnet.sh
@@ -1,7 +1,15 @@
 #!/usr/bin/env bash
+set -euo pipefail
 
-# Path to your .csproj file (relative to script location)
-PROJECT_PATH="./backend/backend.csproj"
+if [[ -n "${AGENT_SETUP:-}" ]]; then
+  echo "AGENT_SETUP is set. These scripts are only for setting up the agent." >&2
+  exit 1
+fi
+
+# Path to your .csproj file (relative to repository root)
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+PROJECT_PATH="$REPO_ROOT/backend/backend.csproj"
 
 # .NET SDK version to install
 SDK_VERSION="9.0"


### PR DESCRIPTION
## Summary
- move install scripts to `scripts/`
- add AGENT_SETUP guard to each script
- create `scripts/setup-agent.sh` orchestrating setup
- update documentation for new locations

## Testing
- `bun run lint`
- `bun run test`


------
https://chatgpt.com/codex/tasks/task_e_68692c85de8483249d0ece339430ec15