### PR TITLE
chore: add Olve.Results dependency

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,6 +25,7 @@ using **bun**. Run backend commands from the `backend/` directory using the
   Dev dependency `@microsoft/kiota` provides the CLI for generating
   TypeScript API clients from the OpenAPI spec.
 - `api/` – generated OpenAPI specification for the backend.
+- `docs/` – documentation such as dependency usage guides.
 - `README.md` – project overview and quickstart instructions.
 - `.github/workflows/ci.yml` – GitHub Actions workflow that runs `bun run lint`
   and `bun run test` on every push and pull request.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,12 +18,7 @@ using **bun**. Run backend commands from the `backend/` directory using the
     GitHub Actions locally.
   - `setup-agent.sh` runs the above scripts and then sets the `AGENT_SETUP`
     environment variable.
-- `package.json` – scripts for dev, build, lint, test and API spec generation.
--  Run `bun run apigen` to regenerate `api/api-spec.json`.
--  These scripts reference
-  configuration files under `frontend/` so run them from the repo root.
-  Dev dependency `@microsoft/kiota` provides the CLI for generating
-  TypeScript API clients from the OpenAPI spec.
+- `package.json` – scripts for dev, build, lint, test and API spec generation. Run `bun run apigen` to regenerate `api/api-spec.json`. These scripts reference configuration files under `frontend/` so run them from the repo root. Dev dependency `@microsoft/kiota` provides the CLI for generating TypeScript API clients from the OpenAPI spec.
 - `api/` – generated OpenAPI specification for the backend.
 - `docs/` – documentation such as dependency usage guides.
 - `README.md` – project overview and quickstart instructions.

--- a/backend/AGENTS.md
+++ b/backend/AGENTS.md
@@ -18,5 +18,6 @@ dotnet run
 - Run `bun run lint` to verify formatting with `dotnet format`.
 - Generate the OpenAPI spec with `bun run apigen`. This writes
   `api/api-spec.json` at the repository root.
+- Depends on `Olve.Results` 0.23.0 for result-based error handling.
 
 Keep this file updated with any server changes.

--- a/backend/backend.csproj
+++ b/backend/backend.csproj
@@ -11,5 +11,6 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.ApiDescription.Server" Version="9.*" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.*" />
+    <PackageReference Include="Olve.Results" Version="0.23.0" />
   </ItemGroup>
 </Project>

--- a/docs/dependencies/README.md
+++ b/docs/dependencies/README.md
@@ -1,0 +1,81 @@
+# Olve.Results Usage Guide
+
+This document explains how to use `Olve.Results` in this repository. The library provides lightweight result types to replace exceptions in application code.
+
+## Core Types
+
+- `Result` – represents success or failure without a value. Create with `Result.Success()` or `Result.Failure(IEnumerable<ResultProblem>)`.
+- `Result<T>` – same as `Result` but carries a value on success. Use `Result<T>.Success(value)` or `Result<T>.Failure(...)`.
+- `DeletionResult` – specialized result for delete operations. Distinguishes between success, not found, and error states.
+- `ResultProblem` – describes a single problem and captures file and line information automatically.
+- `ResultProblemCollection` – enumerable wrapper over multiple problems with helpers such as `Append`, `Prepend` and `Merge`.
+
+## Helpers
+
+- `Result.Chain` – execute functions in order, stopping at the first failure.
+- `Result.Concat` – execute multiple functions and collect their values if all succeed.
+- `Result.Try` – convert exceptions into `ResultProblem` instances.
+- `IfProblem` – run an action if the result has problems, often used to add context.
+- `ResultEnumerableExtensions` – utilities for lists of results: `HasProblems`, `TryPickProblems`, `GetValues` and `GetProblems`.
+- `ResultFuncExtensions` – turn `Action<T>` into `Func<T, Result>` for chaining.
+
+## Usage Patterns
+
+1. **Return Results**
+   Every significant operation returns `Result` or `Result<T>`:
+   ```csharp
+   public Result<Id<Track>> AddTrack(TrackPoint start, TrackPoint end)
+   {
+       var track = new Track(Id<Track>.New(), start, end);
+       _tracks.Add(track.Id, track);
+       return track.Id;
+   }
+   ```
+
+2. **Check for Problems Immediately**
+   Use `TryPickProblems` after each call. Add context using `Prepend`:
+   ```csharp
+   var terrainResult = terrainLoader.Load().IfProblem(p => p.Prepend("loading terrain"));
+   if (terrainResult.TryPickProblems(out var problems))
+       return problems;
+   ```
+
+3. **Chaining Operations**
+   Combine multiple steps with `Result.Chain` or `Result.Concat`:
+   ```csharp
+   private Result<(GL, IInputContext)> SetupContexts() =>
+       Result.Concat(
+           () => Result.Try<GL>(() => window.CreateOpenGL(), "Error creating GL"),
+           () => Result.Try<IInputContext>(() => window.CreateInput(), "Error creating input")
+       );
+   ```
+
+4. **Collecting Problems Across Services**
+   Use `ResultEnumerableExtensions.TryPickProblems` to aggregate failures:
+   ```csharp
+   foreach (var service in _sceneServices)
+       _loadResults.Add(service.Load());
+
+   if (_loadResults.TryPickProblems(out var problems))
+       return problems.Prepend("scene load failed");
+   ```
+
+5. **Logging Problems**
+   Convert problems to readable messages before logging:
+   ```csharp
+   if (result.TryPickProblems(out var problems))
+       foreach (var problem in problems)
+           Console.WriteLine(problem.ToDebugString());
+   ```
+
+## Best Practices
+
+- Always prefer `Result`/`Result<T>` over exceptions for predictable control flow.
+- Annotate problems with additional context using `Prepend` when propagating errors.
+- Use `Result.Try` around operations that may throw.
+- `IfProblem` is useful for minor adjustments without branching.
+- Return `DeletionResult.NotFound()` when a delete target does not exist.
+- Collect results from multiple services and merge problems for centralized error handling.
+
+Following these patterns keeps error handling explicit and consistent across the codebase.
+


### PR DESCRIPTION
## Summary
- add Olve.Results 0.23.0 to backend
- document Olve.Results usage in docs/dependencies
- note docs folder in root AGENTS
- update backend AGENTS about Olve.Results

## Testing
- `biome lint .`
- `dotnet format --verify-no-changes`
- `bun run test`


------
https://chatgpt.com/codex/tasks/task_e_6869edc446b883248948250bc04c4393