### PR TITLE
Add run command endpoint

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,6 +11,7 @@ using **bun**. Run backend commands from the `backend/` directory using the
 - `frontend/` – current Svelte + TypeScript UI. See `frontend/AGENTS.md` for all
   details.
 - `backend/` – ASP.NET Core Minimal API server. See `backend/AGENTS.md`.
+  The server exposes `GET /ping` and `POST /command`.
 - `scripts/` – helper scripts for preparing a development environment:
   - `setup-bun.sh` installs Bun and runs `bun install`.
   - `setup-dotnet.sh` installs the .NET SDK and pre-restores backend packages.

--- a/api/api-spec.json
+++ b/api/api-spec.json
@@ -23,9 +23,220 @@
           }
         }
       }
+    },
+    "/command": {
+      "post": {
+        "tags": [
+          "backend"
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "string"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK"
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/ResultProblem"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
     }
   },
-  "components": { },
+  "components": {
+    "schemas": {
+      "ElementType": {
+        "type": "integer"
+      },
+      "Exception": {
+        "type": "object",
+        "properties": {
+          "targetSite": {
+            "$ref": "#/components/schemas/MethodBase"
+          },
+          "message": {
+            "type": "string",
+            "nullable": true
+          },
+          "data": {
+            "type": "object",
+            "nullable": true
+          },
+          "innerException": {
+            "$ref": "#/components/schemas/Exception"
+          },
+          "helpLink": {
+            "type": "string",
+            "nullable": true
+          },
+          "source": {
+            "type": "string",
+            "nullable": true
+          },
+          "hResult": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "stackTrace": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "nullable": true
+      },
+      "IPath": {
+        "type": "object",
+        "properties": {
+          "elementType": {
+            "$ref": "#/components/schemas/ElementType"
+          },
+          "absolute": {
+            "$ref": "#/components/schemas/IPath"
+          },
+          "parent": {
+            "$ref": "#/components/schemas/IPath"
+          },
+          "children": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/IPath2"
+            },
+            "nullable": true
+          },
+          "path": {
+            "type": "string",
+            "nullable": true
+          },
+          "platform": {
+            "$ref": "#/components/schemas/PathPlatform"
+          },
+          "type": {
+            "$ref": "#/components/schemas/PathType"
+          },
+          "parentPure": {
+            "$ref": "#/components/schemas/IPurePath"
+          },
+          "name": {
+            "type": "string",
+            "nullable": true
+          }
+        }
+      },
+      "IPath2": {
+        "type": "object",
+        "properties": {
+          "elementType": {
+            "$ref": "#/components/schemas/ElementType"
+          },
+          "absolute": {
+            "$ref": "#/components/schemas/IPath"
+          },
+          "parent": {
+            "$ref": "#/components/schemas/IPath"
+          },
+          "children": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/IPath2"
+            },
+            "nullable": true
+          },
+          "path": {
+            "type": "string",
+            "nullable": true
+          },
+          "platform": {
+            "$ref": "#/components/schemas/PathPlatform"
+          },
+          "type": {
+            "$ref": "#/components/schemas/PathType"
+          },
+          "parentPure": {
+            "$ref": "#/components/schemas/IPurePath"
+          },
+          "name": {
+            "type": "string",
+            "nullable": true
+          }
+        }
+      },
+      "MethodBase": {
+        "nullable": true
+      },
+      "PathPlatform": {
+        "type": "integer"
+      },
+      "PathType": {
+        "type": "integer"
+      },
+      "ProblemOriginInformation": {
+        "type": "object",
+        "properties": {
+          "filePath": {
+            "$ref": "#/components/schemas/IPath"
+          },
+          "lineNumber": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "linkString": {
+            "type": "string",
+            "nullable": true
+          }
+        }
+      },
+      "ResultProblem": {
+        "type": "object",
+        "properties": {
+          "message": {
+            "type": "string",
+            "nullable": true
+          },
+          "tags": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "severity": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "args": {
+            "type": "array",
+            "nullable": true
+          },
+          "source": {
+            "type": "string",
+            "nullable": true
+          },
+          "exception": {
+            "$ref": "#/components/schemas/Exception"
+          },
+          "originInformation": {
+            "$ref": "#/components/schemas/ProblemOriginInformation"
+          }
+        }
+      }
+    }
+  },
   "tags": [
     {
       "name": "backend"

--- a/backend/AGENTS.md
+++ b/backend/AGENTS.md
@@ -13,7 +13,10 @@ cd backend
 dotnet run
 ```
 
-- The API exposes a single endpoint `GET /ping` that returns `"pong"`.
+- The API exposes two endpoints:
+  - `GET /ping` returns `"pong"`.
+  - `POST /command` runs a command provided in the request body and returns
+    `400` on failure.
 - `Olve.Results` handles errors consistently; see `../docs/dependencies/Olve.Results.md`.
 - All C# files use `nullable` reference types and implicit usings.
 - Run `bun run lint` to verify formatting with `dotnet format`.

--- a/backend/ConsoleRunCommandHandler.cs
+++ b/backend/ConsoleRunCommandHandler.cs
@@ -1,0 +1,12 @@
+namespace Olve.Trains.Backend;
+
+using Olve.Results;
+
+public class ConsoleRunCommandHandler : IRunCommandHandler
+{
+    public Task<Result> RunAsync(string command)
+    {
+        Console.WriteLine($"Running command: {command}");
+        return Task.FromResult(Result.Success());
+    }
+}

--- a/backend/IRunCommandHandler.cs
+++ b/backend/IRunCommandHandler.cs
@@ -1,0 +1,8 @@
+namespace Olve.Trains.Backend;
+
+using Olve.Results;
+
+public interface IRunCommandHandler
+{
+    Task<Result> RunAsync(string command);
+}

--- a/backend/Program.cs
+++ b/backend/Program.cs
@@ -1,12 +1,30 @@
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Hosting;
+using Microsoft.AspNetCore.Mvc;
+using Olve.Trains.Backend;
+using Olve.Results;
+using Microsoft.AspNetCore.Http.HttpResults;
+using Microsoft.AspNetCore.Http;
 
 var builder = WebApplication.CreateBuilder(args);
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddOpenApi();
+builder.Services.AddSingleton<IRunCommandHandler, ConsoleRunCommandHandler>();
 var app = builder.Build();
 
 app.MapGet("/ping", () => "pong").WithOpenApi();
+app.MapPost("/command", async Task<Results<Ok, BadRequest<IEnumerable<ResultProblem>>>> ([FromBody] string command, IRunCommandHandler handler) =>
+{
+    var result = await handler.RunAsync(command);
+    if (result.TryPickProblems(out var problems))
+    {
+        return TypedResults.BadRequest<IEnumerable<ResultProblem>>(problems);
+    }
+    return TypedResults.Ok();
+})
+    .Produces(StatusCodes.Status200OK)
+    .Produces<IEnumerable<ResultProblem>>(StatusCodes.Status400BadRequest)
+    .WithOpenApi();
 
 app.Run();


### PR DESCRIPTION
## Summary
- implement IRunCommandHandler and console-based implementation
- expose POST `/command` endpoint returning 400 on failure
- generate updated API specification
- document new endpoint in AGENTS

## Testing
- `dotnet build`
- `bun run lint` *(fails to run `kiota` during apigen due to missing CLI)*

------
https://chatgpt.com/codex/tasks/task_e_686a09136ce88324957c9d2b6266bedd