### PR TITLE
feat: add IPath JSON converter

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,6 +30,7 @@ using **bun**. Run backend commands from the `backend/` directory using the
 - `api/` – generated OpenAPI specification for the backend.
 - `README.md` – project overview and quickstart instructions.
 - `docs/dependencies/` – usage docs for third-party packages, e.g. `Olve.Results.md`.
+- `backend/IPathJsonConverter.cs` – JSON converter for `IPath` using `Path.Create`.
 - `.github/workflows/ci.yml` – GitHub Actions workflow that runs `bun run lint`
   and `bun run test` on every push and pull request.
 ## Linting

--- a/backend/AGENTS.md
+++ b/backend/AGENTS.md
@@ -20,5 +20,7 @@ dotnet run
 - Generate the OpenAPI spec and TypeScript client with `bun run apigen`.
   This writes `api/api-spec.json` and updates
   `frontend/src/generated/api`.
+- `IPathJsonConverter` serializes `IPath` values by calling
+  `value.Path` and deserializes with `Path.Create(string)`.
 
 Keep this file updated with any server changes.

--- a/backend/IPathJsonConverter.cs
+++ b/backend/IPathJsonConverter.cs
@@ -1,0 +1,20 @@
+using System;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Olve.Paths;
+
+namespace Backend.Serialization;
+
+public sealed class IPathJsonConverter : JsonConverter<IPath>
+{
+    public override IPath? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+        var pathString = reader.GetString();
+        return pathString is null ? null : Olve.Paths.Path.Create(pathString);
+    }
+
+    public override void Write(Utf8JsonWriter writer, IPath value, JsonSerializerOptions options)
+    {
+        writer.WriteStringValue(value.Path);
+    }
+}

--- a/backend/Program.cs
+++ b/backend/Program.cs
@@ -5,6 +5,8 @@ using Microsoft.Extensions.Hosting;
 var builder = WebApplication.CreateBuilder(args);
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddOpenApi();
+builder.Services.ConfigureHttpJsonOptions(options =>
+    options.SerializerOptions.Converters.Add(new Backend.Serialization.IPathJsonConverter()));
 var app = builder.Build();
 
 app.MapGet("/ping", () => "pong").WithOpenApi();

--- a/backend/backend.csproj
+++ b/backend/backend.csproj
@@ -12,5 +12,6 @@
     <PackageReference Include="Microsoft.Extensions.ApiDescription.Server" Version="9.*" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.*" />
     <PackageReference Include="Olve.Results" Version="0.23.0" />
+    <PackageReference Include="Olve.Paths" Version="0.23.0" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
## Summary
- allow backend to serialize `IPath` using a custom converter
- wire converter into JSON options
- document new functionality in AGENTS files

## Testing
- `bun run test`
- `dotnet format --verify-no-changes`


------
https://chatgpt.com/codex/tasks/task_e_686a258777b083249b1b11d51cdfad14