### PR TITLE
feat: add run command endpoint

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,6 +31,8 @@ using **bun**. Run backend commands from the `backend/` directory using the
 - `README.md` – project overview and quickstart instructions.
 - `docs/dependencies/` – usage docs for third-party packages, e.g. `Olve.Results.md`.
 - `backend/IPathJsonConverter.cs` – JSON converter for `IPath` using `Path.Create`.
+- `backend/RunCommand.cs` – defines `IRunCommandHandler` and a logging
+  implementation used by the `/run-command` endpoint.
 - `.github/workflows/ci.yml` – GitHub Actions workflow that runs `bun run lint`
   and `bun run test` on every push and pull request.
 ## Linting

--- a/api/api-spec.json
+++ b/api/api-spec.json
@@ -23,9 +23,164 @@
           }
         }
       }
+    },
+    "/run-command": {
+      "post": {
+        "tags": [
+          "Olve.Trains.UI.Server"
+        ],
+        "operationId": "RunCommand",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/RunCommandRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SuccessResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/ResultProblem"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
     }
   },
-  "components": { },
+  "components": {
+    "schemas": {
+      "Exception": {
+        "type": "object",
+        "properties": {
+          "targetSite": {
+            "$ref": "#/components/schemas/MethodBase"
+          },
+          "message": {
+            "type": "string",
+            "nullable": true
+          },
+          "data": {
+            "type": "object",
+            "nullable": true
+          },
+          "innerException": {
+            "$ref": "#/components/schemas/Exception"
+          },
+          "helpLink": {
+            "type": "string",
+            "nullable": true
+          },
+          "source": {
+            "type": "string",
+            "nullable": true
+          },
+          "hResult": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "stackTrace": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "nullable": true
+      },
+      "IPath": { },
+      "MethodBase": {
+        "nullable": true
+      },
+      "ProblemOriginInformation": {
+        "type": "object",
+        "properties": {
+          "filePath": {
+            "$ref": "#/components/schemas/IPath"
+          },
+          "lineNumber": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "linkString": {
+            "type": "string",
+            "nullable": true
+          }
+        }
+      },
+      "ResultProblem": {
+        "type": "object",
+        "properties": {
+          "message": {
+            "type": "string",
+            "nullable": true
+          },
+          "tags": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "severity": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "args": {
+            "type": "array",
+            "nullable": true
+          },
+          "source": {
+            "type": "string",
+            "nullable": true
+          },
+          "exception": {
+            "$ref": "#/components/schemas/Exception"
+          },
+          "originInformation": {
+            "$ref": "#/components/schemas/ProblemOriginInformation"
+          }
+        }
+      },
+      "RunCommandRequest": {
+        "required": [
+          "command"
+        ],
+        "type": "object",
+        "properties": {
+          "command": {
+            "type": "string"
+          }
+        }
+      },
+      "SuccessResponse": {
+        "type": "object",
+        "properties": {
+          "success": {
+            "type": "boolean",
+            "default": true
+          }
+        }
+      }
+    }
+  },
   "tags": [
     {
       "name": "Olve.Trains.UI.Server"

--- a/backend/AGENTS.md
+++ b/backend/AGENTS.md
@@ -13,7 +13,10 @@ cd backend
 dotnet run
 ```
 
-- The API exposes a single endpoint `GET /ping` that returns `"pong"`.
+- The API exposes `GET /` returning a simple string.
+- `POST /run-command` accepts `{ command: string }` and runs it using
+  `IRunCommandHandler`. The default `LoggingRunCommandHandler` just logs
+  the command.
 - `Olve.Results` handles errors consistently; see `../docs/dependencies/Olve.Results.md`.
 - All C# files use `nullable` reference types and implicit usings.
 - Run `bun run lint` to verify formatting with `dotnet format`.

--- a/backend/ApplicationConfiguration.cs
+++ b/backend/ApplicationConfiguration.cs
@@ -1,4 +1,6 @@
-﻿namespace Olve.Trains.UI.Server;
+using Microsoft.AspNetCore.Http.HttpResults;
+using Olve.Results;
+namespace Olve.Trains.UI.Server;
 
 public static class ApplicationConfiguration
 {
@@ -6,7 +8,9 @@ public static class ApplicationConfiguration
     {
         builder.Services.AddEndpointsApiExplorer();
         builder.Services.AddOpenApi();
-        builder.Services.ConfigureHttpJsonOptions(options => options.SerializerOptions.Converters.Add(new PathJsonConverter()));
+        builder.Services.ConfigureHttpJsonOptions(options =>
+            options.SerializerOptions.Converters.Add(new PathJsonConverter()));
+        builder.Services.AddSingleton<IRunCommandHandler, LoggingRunCommandHandler>();
 
         return builder;
     }
@@ -14,6 +18,20 @@ public static class ApplicationConfiguration
     public static WebApplication ConfigureApplication(this WebApplication app)
     {
         app.MapGet("/", () => "Olve.Trains.UI.Server");
+
+        app.MapPost("/run-command", async Task<Results<Ok<SuccessResponse>, BadRequest<ResultProblem[]>>> (
+            RunCommandRequest request,
+            IRunCommandHandler handler,
+            CancellationToken ct) =>
+        {
+            var result = await handler.RunAsync(request.Command, ct);
+            if (result.TryPickProblems(out var problems))
+                return TypedResults.BadRequest(problems.ToArray());
+
+            return TypedResults.Ok(new SuccessResponse());
+        })
+        .WithName("RunCommand")
+        .WithOpenApi();
 
         return app;
     }

--- a/backend/RunCommand.cs
+++ b/backend/RunCommand.cs
@@ -1,0 +1,26 @@
+using Olve.Results;
+using Microsoft.Extensions.Logging;
+namespace Olve.Trains.UI.Server;
+
+public sealed record RunCommandRequest(string Command);
+
+public interface IRunCommandHandler
+{
+    Task<Result> RunAsync(string command, CancellationToken cancellationToken);
+}
+
+public sealed class LoggingRunCommandHandler : IRunCommandHandler
+{
+    private readonly ILogger<LoggingRunCommandHandler> _logger;
+
+    public LoggingRunCommandHandler(ILogger<LoggingRunCommandHandler> logger)
+    {
+        _logger = logger;
+    }
+
+    public Task<Result> RunAsync(string command, CancellationToken cancellationToken)
+    {
+        _logger.LogInformation("Run command: {Command}", command);
+        return Task.FromResult(Result.Success());
+    }
+}

--- a/backend/SuccessResponse.cs
+++ b/backend/SuccessResponse.cs
@@ -1,0 +1,3 @@
+namespace Olve.Trains.UI.Server;
+
+public sealed record SuccessResponse(bool Success = true);


### PR DESCRIPTION
## Summary
- implement `IRunCommandHandler` with a logging implementation
- expose `POST /run-command` minimal API
- generate updated OpenAPI spec
- document backend changes in `AGENTS.md`

## Testing
- `bun run lint` *(fails: Found 19 warnings)*
- `dotnet format --verify-no-changes`

------
https://chatgpt.com/codex/tasks/task_e_686a6f8ac9b0832486bceebc9d95b0b6