### PR TITLE
Fix OpenAPI IPath schema

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,6 +27,8 @@ using **bun**. Run backend commands from the `backend/` directory using the
   `kiota generate --language TypeScript -d api/api-spec.json -o
   frontend/src/generated/api --class-name ApiClient --namespace-name
   Olve.Trains.ApiClient` behind the scenes.
+- If the Kiota CLI fails to download (offline), run the `dotnet build` portion
+  and manually update `api/api-spec.json` so `IPath` has `{ "type": "string" }`.
 - `api/` – generated OpenAPI specification for the backend.
 - `README.md` – project overview and quickstart instructions.
 - `docs/dependencies/` – usage docs for third-party packages, e.g. `Olve.Results.md`.

--- a/api/api-spec.json
+++ b/api/api-spec.json
@@ -106,7 +106,9 @@
         },
         "nullable": true
       },
-      "IPath": { },
+      "IPath": {
+        "type": "string"
+      },
       "MethodBase": {
         "nullable": true
       },


### PR DESCRIPTION
## Summary
- update API spec to treat `IPath` as a string
- document manual patch for offline Kiota CLI

## Testing
- `dotnet build backend/Olve.Trains.UI.Server.csproj -p:OpenApiGenerateDocuments=true`
- `bun run apigen` *(fails: connect ENETUNREACH)*

------
https://chatgpt.com/codex/tasks/task_e_686a73b6349c83249f2e1296295faf62