### PR TITLE
Add TUnit docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,6 +11,9 @@ using **bun**. Run backend commands from the `backend/` directory using the
 - `frontend/` – current Svelte + TypeScript UI. See `frontend/AGENTS.md` for all
   details.
 - `backend/` – ASP.NET Core Minimal API server. See `backend/AGENTS.md`.
+  Backend tests live in `backend-tests/` and use
+  [TUnit](https://tunit.dev/). Run them with `dotnet test` from the repository root.
+  Usage details are in `docs/dependencies/TUnit.md`.
 - `scripts/` – helper scripts for preparing a development environment:
   - `setup-bun.sh` installs Bun, runs `bun install`, and sets `BUN_SETUP`.
   - `setup-dotnet.sh` installs the .NET SDK, restores packages, and sets `DOTNET_SETUP`.
@@ -30,7 +33,7 @@ using **bun**. Run backend commands from the `backend/` directory using the
   and manually update `api/api-spec.json` so `IPath` has `{ "type": "string" }`.
 - `api/` – generated OpenAPI specification for the backend.
 - `README.md` – project overview and quickstart instructions.
-- `docs/dependencies/` – usage docs for third-party packages, e.g. `Olve.Results.md`.
+- `docs/dependencies/` – usage docs for third-party packages, e.g. `Olve.Results.md` and `TUnit.md`.
 - `backend/IPathJsonConverter.cs` – JSON converter for `IPath` using `Path.Create`.
 - `backend/RunCommand.cs` – defines `IRunCommandHandler` and a logging
   implementation used by the `/run-command` endpoint.

--- a/backend-tests/Olve.Trains.UI.Server.Tests.csproj
+++ b/backend-tests/Olve.Trains.UI.Server.Tests.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net9.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="TUnit" Version="0.24.0" />
+    <ProjectReference Include="../backend/Olve.Trains.UI.Server.csproj" PrivateAssets="all" />
+  </ItemGroup>
+
+</Project>

--- a/backend-tests/RunCommandTests.cs
+++ b/backend-tests/RunCommandTests.cs
@@ -1,0 +1,24 @@
+using Microsoft.Extensions.Logging.Abstractions;
+using Olve.Trains.UI.Server.Commands;
+using Olve.Trains.UI.Server.Logs;
+
+namespace Olve.Trains.UI.Server.Tests;
+
+public class RunCommandTests
+{
+    [Test]
+    public async Task RunCommand_Adds_Log_Message()
+    {
+        var logs = new InMemoryGetLogsHandler();
+        var logger = NullLogger<LoggingRunCommandHandler>.Instance;
+        var handler = new LoggingRunCommandHandler(logger, logs);
+
+        await handler.RunAsync("sample", CancellationToken.None);
+
+        var result = await logs.GetAsync(CancellationToken.None);
+        await Assert.That(result.TryPickProblems(out var problems, out var entries)).IsFalse();
+        await Assert.That(entries).HasCount(1);
+        await Assert.That(entries![0].Message).IsEqualTo("sample");
+    }
+}
+

--- a/backend/AGENTS.md
+++ b/backend/AGENTS.md
@@ -20,6 +20,7 @@ dotnet run
 - `GET /logs` returns an array of `LogMessage` instances via
   `IGetLogsHandler` which stores messages in memory.
 - `Olve.Results` handles errors consistently; see `../docs/dependencies/Olve.Results.md`.
+- See `../docs/dependencies/TUnit.md` for test framework usage.
 - All C# files use `nullable` reference types and implicit usings.
 - Run `bun run lint` to verify formatting with `dotnet format`.
 - Generate the OpenAPI spec and TypeScript client with `bun run apigen`.
@@ -27,5 +28,9 @@ dotnet run
   `frontend/src/generated/api`.
 - `IPathJsonConverter` serializes `IPath` values by calling
   `value.Path` and deserializes with `Path.Create(string)`.
+
+## Testing
+Backend tests live in `../backend-tests/` and use the TUnit framework.
+Run `dotnet test` in `../backend-tests` to execute them.
 
 Keep this file updated with any server changes.

--- a/docs/dependencies/TUnit.md
+++ b/docs/dependencies/TUnit.md
@@ -1,0 +1,30 @@
+# TUnit Usage Guide
+
+This document explains how to write and run tests with [TUnit](https://tunit.dev/).
+TUnit generates tests at compile time and executes them with the new Microsoft Testing Platform.
+
+## Project Setup
+- Add the `TUnit` NuGet package to your test project.
+- Target `net9.0` and output an `Exe` assembly.
+- Reference the project under test via `ProjectReference`.
+
+## Running Tests
+- Invoke `dotnet test` or `dotnet run` on the test project.
+- Tests are discovered at build time; no reflection is used.
+- Parallel execution is enabled by default.
+
+## Test Attributes
+- `[Test]` marks a method as a test.
+- `[Arguments]` provides data-driven inputs.
+- `[DependsOn]` controls execution order.
+- `[Retry]` reruns a failing test the specified number of times.
+- `[ParallelLimit]` restricts concurrent execution.
+
+## Fluent Assertions
+TUnit ships its own assertion library:
+```csharp
+await Assert.That(result.IsSuccess).IsTrue();
+await Assert.That(value).IsEqualTo(42);
+```
+
+Use these helpers for asynchronous conditions and rich diagnostics.


### PR DESCRIPTION
## Summary
- document backend tests with link to TUnit guide
- add `docs/dependencies/TUnit.md`

## Testing
- `dotnet test backend-tests/Olve.Trains.UI.Server.Tests.csproj --no-restore --verbosity minimal`
- `bun run lint` *(fails: Found 30 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_686b95280f2083249042990dae38792f