### PR TITLE
fix: restore App initialLogs prop

### DIFF
--- a/frontend/AGENTS.md
+++ b/frontend/AGENTS.md
@@ -19,6 +19,8 @@ All build scripts assume you run them from the repository root using **bun**.
   spec. Run `bun run apigen` at the repository root to update these files.
 - `src/api/client.ts` initializes the generated client and sets the backend
   base URL. This client is the only mechanism for calling the server API.
+- `src/App.svelte` exposes an optional `initialLogs` prop so tests can inject
+  starting log data without hitting the network.
 
 ## Coding style
 - Prefer modern ES6 syntax.

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -5,7 +5,8 @@ import type { LogMessage } from './api/logMessage';
 import { fetchLogs } from './services/logService.js';
 import { runCommand as executeCommand } from './services/commandService.js';
 
-export const initialLogs: LogMessage[] = [];
+/** Optional starting logs for easier testing */
+export let initialLogs: LogMessage[] = [];
 let logs: LogMessage[] = initialLogs;
 let command = '';
 let commandResponse = '';


### PR DESCRIPTION
## Summary
- restore `initialLogs` prop in `App.svelte`
- document optional `initialLogs` prop in frontend AGENTS guide

## Testing
- `bun run lint`
- `bun run test`
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_686bbf7f637083249022099dae17eab9