### PR TITLE
Add typed result mapping

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,8 +33,9 @@ using **bun**. Run backend commands from the `backend/` directory using the
   implementation used by the `/run-command` endpoint.
 - `backend/Logs.cs` – contains `LogMessage` and an in-memory
   `IGetLogsHandler` used by the `/logs` endpoint.
-- `backend/ResultMappingExtensions.cs` – adds `WithResultMapping()` to map
-  `Result` values to HTTP responses.
+- `backend/ResultMappingExtensions.cs` – `WithResultMapping()` and
+  `WithResultMapping<T>()` convert `Result` values to HTTP responses and
+  document 200/400 responses.
 - `.github/workflows/ci.yml` – GitHub Actions workflow that runs `bun run lint`
   and `bun run test` on every push and pull request.
 ## Linting
@@ -45,8 +46,9 @@ Always update this `AGENTS.md` with repository changes so LLM agents can operate
 ## Tasks
 ### Mapping `Result` types to HTTP responses
 
-Use `WithResultMapping()` on endpoints that return `Olve.Results` to convert
-them to HTTP results automatically:
+Use `WithResultMapping()` or the generic `WithResultMapping<T>()` on endpoints
+that return `Olve.Results` to convert them to HTTP results automatically and
+add `200`/`400` documentation:
 
 ```csharp
 app.MapPost("/run-command", (
@@ -55,6 +57,11 @@ app.MapPost("/run-command", (
     CancellationToken ct) =>
         handler.RunAsync(req.Command, ct))
    .WithResultMapping();
+
+app.MapGet("/logs", (
+    IGetLogsHandler handler,
+    CancellationToken ct) => handler.GetAsync(ct))
+   .WithResultMapping<IReadOnlyList<LogMessage>>();
 ```
 
 ### Adding FE Test Fixtures

--- a/api/api-spec.json
+++ b/api/api-spec.json
@@ -42,11 +42,17 @@
         },
         "responses": {
           "200": {
-            "description": "OK",
+            "description": "OK"
+          },
+          "400": {
+            "description": "Bad Request",
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Result"
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/ResultProblem"
+                  }
                 }
               }
             }
@@ -66,7 +72,23 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ResultOfIReadOnlyListOfLogMessage"
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/LogMessage"
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/ResultProblem"
+                  }
                 }
               }
             }
@@ -113,7 +135,9 @@
         },
         "nullable": true
       },
-      "IPath": { },
+      "IPath": {
+        "type": "string"
+      },
       "IPath2": {
         "nullable": true
       },
@@ -173,49 +197,6 @@
           },
           "linkString": {
             "type": "string",
-            "nullable": true
-          }
-        }
-      },
-      "Result": {
-        "type": "object",
-        "properties": {
-          "succeeded": {
-            "type": "boolean"
-          },
-          "failed": {
-            "type": "boolean"
-          },
-          "problems": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/ResultProblem"
-            },
-            "nullable": true
-          }
-        }
-      },
-      "ResultOfIReadOnlyListOfLogMessage": {
-        "type": "object",
-        "properties": {
-          "succeeded": {
-            "type": "boolean"
-          },
-          "failed": {
-            "type": "boolean"
-          },
-          "problems": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/ResultProblem"
-            },
-            "nullable": true
-          },
-          "value": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/LogMessage"
-            },
             "nullable": true
           }
         }

--- a/backend/AGENTS.md
+++ b/backend/AGENTS.md
@@ -20,8 +20,9 @@ dotnet run
 - `GET /logs` returns an array of `LogMessage` instances via
   `IGetLogsHandler` which stores messages in memory.
 - `Olve.Results` handles errors consistently; see `../docs/dependencies/Olve.Results.md`.
-- `WithResultMapping()` converts `Result` and `Result<T>` return values to
-  `TypedResults` automatically.
+ - `WithResultMapping()` and `WithResultMapping<T>()` convert `Result` and `Result<T>`
+   return values to `TypedResults` automatically and register `200` and `400`
+   responses for OpenAPI docs.
 - See `../docs/dependencies/TUnit.md` for test framework usage.
 - All C# files use `nullable` reference types and implicit usings.
 - Run `bun run lint` to verify formatting with `dotnet format`.

--- a/backend/ApplicationConfiguration.cs
+++ b/backend/ApplicationConfiguration.cs
@@ -45,7 +45,7 @@ public static class ApplicationConfiguration
         app.MapGet("/logs", (
                 IGetLogsHandler handler,
                 CancellationToken ct) => handler.GetAsync(ct))
-            .WithResultMapping()
+            .WithResultMapping<IReadOnlyList<LogMessage>>()
             .WithName("GetLogs")
             .WithOpenApi();
 

--- a/backend/ResultMappingExtensions.cs
+++ b/backend/ResultMappingExtensions.cs
@@ -1,11 +1,26 @@
 using System.Reflection;
 using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
 
 namespace Olve.Trains.UI.Server;
 
 public static class ResultMappingExtensions
 {
     public static RouteHandlerBuilder WithResultMapping(this RouteHandlerBuilder builder)
+    {
+        builder.Produces(StatusCodes.Status200OK)
+               .Produces<ResultProblem[]>(StatusCodes.Status400BadRequest);
+        return AddResultFilter(builder);
+    }
+
+    public static RouteHandlerBuilder WithResultMapping<T>(this RouteHandlerBuilder builder)
+    {
+        builder.Produces<T>(StatusCodes.Status200OK)
+               .Produces<ResultProblem[]>(StatusCodes.Status400BadRequest);
+        return AddResultFilter(builder);
+    }
+
+    private static RouteHandlerBuilder AddResultFilter(RouteHandlerBuilder builder)
     {
         return builder.AddEndpointFilterFactory((context, next) =>
         {


### PR DESCRIPTION
## Summary
- support `WithResultMapping<T>()` to register typed 200 results
- update application setup to document `GET /logs` with typed array
- refresh API spec and docs

## Testing
- `bun run lint`
- `dotnet test backend-tests/Olve.Trains.UI.Server.Tests.csproj -v minimal`


------
https://chatgpt.com/codex/tasks/task_e_686bc2051064832486741f95a1ebb131