### PR TITLE
Fix IPath serialization

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,7 +28,7 @@ using **bun**. Run backend commands from the `backend/` directory using the
 - `api/` – generated OpenAPI specification for the backend.
 - `README.md` – project overview and quickstart instructions.
 - `docs/dependencies/` – usage docs for third-party packages, e.g. `Olve.Results.md` and `TUnit.md`.
-- `backend/IPathJsonConverter.cs` – JSON converter for `IPath` using `Path.Create`.
+- `backend/Api/PathJsonConverter.cs` – JSON converter for `IPath` using `Path.Create`.
 - `backend/RunCommand.cs` – defines `IRunCommandHandler` and a logging
   implementation used by the `/run-command` endpoint.
 - `backend/Logs.cs` – contains `LogMessage` and an in-memory

--- a/api/api-spec.json
+++ b/api/api-spec.json
@@ -5,25 +5,6 @@
     "version": "1.0.0"
   },
   "paths": {
-    "/": {
-      "get": {
-        "tags": [
-          "Olve.Trains.UI.Server"
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "text/plain": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
     "/run-command": {
       "post": {
         "tags": [
@@ -136,9 +117,7 @@
         "nullable": true
       },
       "IPath": {
-        "type": "string"
-      },
-      "IPath2": {
+        "type": "string",
         "nullable": true
       },
       "LogLevel": {
@@ -162,7 +141,7 @@
             "type": "string"
           },
           "sourcePath": {
-            "$ref": "#/components/schemas/IPath2"
+            "$ref": "#/components/schemas/IPath"
           },
           "sourceLine": {
             "type": "integer",

--- a/backend-tests/ResultMappingTests.cs
+++ b/backend-tests/ResultMappingTests.cs
@@ -1,6 +1,7 @@
 using Microsoft.AspNetCore.Http.HttpResults;
 using Olve.Results;
 using Olve.Trains.UI.Server;
+using Olve.Trains.UI.Server.Api;
 
 namespace Olve.Trains.UI.Server.Tests;
 

--- a/backend/AGENTS.md
+++ b/backend/AGENTS.md
@@ -29,7 +29,7 @@ dotnet run
 - Generate the OpenAPI spec and TypeScript client with `bun run apigen`.
   This writes `api/api-spec.json` and updates
   `frontend/src/generated/api`.
-- `IPathJsonConverter` serializes `IPath` values by calling
+- `PathJsonConverter` serializes `IPath` values by calling
   `value.Path` and deserializes with `Path.Create(string)`.
 
 ## Testing

--- a/backend/Api/ResultMappingExtensions.cs
+++ b/backend/Api/ResultMappingExtensions.cs
@@ -60,14 +60,14 @@ public static class ResultMappingExtensions
         });
     }
 
-    private static IResult ToHttpResult(this Result result)
+    public static IResult ToHttpResult(this Result result)
     {
         return result.TryPickProblems(out var problems)
             ? TypedResults.BadRequest(problems.ToArray())
             : TypedResults.Ok();
     }
 
-    private static IResult ToHttpResult<T>(this Result<T> result)
+    public static IResult ToHttpResult<T>(this Result<T> result)
     {
         return result.TryPickProblems(out var problems, out var value)
             ? TypedResults.BadRequest(problems.ToArray())

--- a/backend/Logs/LogMessage.cs
+++ b/backend/Logs/LogMessage.cs
@@ -1,8 +1,12 @@
+using System.Text.Json.Serialization;
+using Olve.Trains.UI.Server.Api;
+
 namespace Olve.Trains.UI.Server.Logs;
 
 public sealed record LogMessage(
     LogLevel Level,
     string Message,
+    [property: JsonConverter(typeof(PathJsonConverter))]
     IPath? SourcePath,
     int? SourceLine,
     DateTime Time,


### PR DESCRIPTION
## Summary
- add `JsonConverter` attribute on `SourcePath`
- expose Result mapping helpers again
- update API spec to map IPath to `string`
- keep docs accurate
- update backend tests for new namespace

## Testing
- `bun run lint`
- `bun run test`
- `dotnet test backend-tests`

------
https://chatgpt.com/codex/tasks/task_e_686bc84462bc8324a3e22a119bea7eb5