### PR TITLE
Add Playwright E2E tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,5 +17,7 @@ jobs:
         with:
           dotnet-version: '9.0.x'
       - run: bun install --frozen-lockfile
+      - run: bunx playwright install --with-deps
       - run: bun run lint
       - run: bun run test
+      - run: bun run e2e

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,6 +14,7 @@ using **bun**. Run backend commands from the `backend/` directory using the
   Backend tests live in `backend-tests/` and use
   [TUnit](https://tunit.dev/). Run them with `dotnet test` from the repository root.
   Usage details are in `docs/dependencies/TUnit.md`.
+- `e2e-tests/` – Playwright end-to-end specs run with `bun run e2e`.
 - `package.json` – scripts for dev, build, lint, test and API spec generation.
 - Run `bun run apigen` to regenerate `api/api-spec.json` and the
   TypeScript client under `frontend/src/generated/api`.
@@ -36,8 +37,8 @@ using **bun**. Run backend commands from the `backend/` directory using the
 - `backend/ResultMappingExtensions.cs` – `WithResultMapping()` and
   `WithResultMapping<T>()` convert `Result` values to HTTP responses and
   document 200/400 responses.
-- `.github/workflows/ci.yml` – GitHub Actions workflow that runs `bun run lint`
-  and `bun run test` on every push and pull request.
+- `.github/workflows/ci.yml` – GitHub Actions workflow that runs `bun run lint`,
+  `bun run test` and `bun run e2e` on every push and pull request.
 ## Linting
 - Run `bun run lint` to check formatting and style across the repo.
   It lints frontend and configuration files via **biome** and verifies C#
@@ -71,4 +72,4 @@ app.MapGet("/logs", (
 3. Write tests in `frontend/tests/*.test.ts` and import any utilities from `frontend/src/` as needed.
 
 A sample test is provided in `frontend/tests/app.test.ts`.
-Integration tests will be introduced alongside the backend as it evolves.
+Playwright E2E specs reside in `e2e-tests/`.

--- a/README.md
+++ b/README.md
@@ -41,6 +41,16 @@ No backend is required. Run the suite with:
 bun run test
 ```
 
+## End-to-End Tests
+
+Playwright drives both the Svelte dev server and the backend to exercise the full stack.
+Start the servers manually with `scripts/start-e2e.sh` or let Playwright handle it automatically.
+Run the suite with:
+
+```bash
+bun run e2e
+```
+
 ## Running GitHub Actions locally
 
 To test workflows defined under `.github/workflows/` without pushing code, use

--- a/backend/AGENTS.md
+++ b/backend/AGENTS.md
@@ -35,5 +35,6 @@ dotnet run
 ## Testing
 Backend tests live in `../backend-tests/` and use the TUnit framework.
 Run `dotnet test` in `../backend-tests` to execute them.
+Playwright E2E tests live in `../e2e-tests/` and run with `bun run e2e` from the repo root.
 
 Keep this file updated with any server changes.

--- a/bun.lock
+++ b/bun.lock
@@ -12,6 +12,7 @@
         "@microsoft/kiota-serialization-json": "^1.0.0-preview.96",
         "@microsoft/kiota-serialization-multipart": "^1.0.0-preview.96",
         "@microsoft/kiota-serialization-text": "^1.0.0-preview.96",
+        "@playwright/test": "^1.53.2",
         "@sveltejs/vite-plugin-svelte": "^3.0.0",
         "@testing-library/dom": "^10.4.0",
         "@testing-library/jest-dom": "^6.6.3",
@@ -157,6 +158,8 @@
     "@open-draft/until": ["@open-draft/until@2.1.0", "", {}, "sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg=="],
 
     "@opentelemetry/api": ["@opentelemetry/api@1.9.0", "", {}, "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg=="],
+
+    "@playwright/test": ["@playwright/test@1.53.2", "", { "dependencies": { "playwright": "1.53.2" }, "bin": { "playwright": "cli.js" } }, "sha512-tEB2U5z74ebBeyfGNZ3Jfg29AnW+5HlWhvHtb/Mqco9pFdZU1ZLNdVb2UtB5CvmiilNr2ZfVH/qMmAROG/XTzw=="],
 
     "@rollup/rollup-android-arm-eabi": ["@rollup/rollup-android-arm-eabi@4.44.2", "", { "os": "android", "cpu": "arm" }, "sha512-g0dF8P1e2QYPOj1gu7s/3LVP6kze9A7m6x0BZ9iTdXK8N5c2V7cpBKHV3/9A4Zd8xxavdhK0t4PnqjkqVmUc9Q=="],
 
@@ -390,6 +393,10 @@
 
     "picomatch": ["picomatch@4.0.2", "", {}, "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg=="],
 
+    "playwright": ["playwright@1.53.2", "", { "dependencies": { "playwright-core": "1.53.2" }, "optionalDependencies": { "fsevents": "2.3.2" }, "bin": { "playwright": "cli.js" } }, "sha512-6K/qQxVFuVQhRQhFsVZ9fGeatxirtrpPgxzBYWyZLEXJzqYwuL4fuNmfOfD5et1tJE4GScKyPNeLhZeRwuTU3A=="],
+
+    "playwright-core": ["playwright-core@1.53.2", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-ox/OytMy+2w1jcYEYlOo1Hhp8hZkLCximMTUTMBXjGUA1KoFfiSZ+DU+3a739jsPY0yoKH2TFy9S2fsJas8yAw=="],
+
     "postcss": ["postcss@8.5.6", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg=="],
 
     "pretty-format": ["pretty-format@27.5.1", "", { "dependencies": { "ansi-regex": "^5.0.1", "ansi-styles": "^5.0.0", "react-is": "^17.0.1" } }, "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ=="],
@@ -529,6 +536,8 @@
     "ansi-escapes/type-fest": ["type-fest@0.21.3", "", {}, "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w=="],
 
     "cliui/wrap-ansi": ["wrap-ansi@7.0.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q=="],
+
+    "playwright/fsevents": ["fsevents@2.3.2", "", { "os": "darwin" }, "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA=="],
 
     "pretty-format/ansi-styles": ["ansi-styles@5.2.0", "", {}, "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA=="],
 

--- a/e2e-tests/app.spec.ts
+++ b/e2e-tests/app.spec.ts
@@ -1,0 +1,12 @@
+import { test, expect } from '@playwright/test';
+
+// Basic example: run a command and see it appear in logs
+
+test('command logs appear', async ({ page }) => {
+  await page.goto('/');
+  await page.fill('#command-input', 'hello');
+  await page.click('#command-send');
+
+  await expect(page.locator('#command-response')).toContainText('succeeded');
+  await expect(page.locator('.log-entry').last()).toContainText('hello');
+});

--- a/frontend/AGENTS.md
+++ b/frontend/AGENTS.md
@@ -48,5 +48,6 @@ All build scripts assume you run them from the repository root using **bun**.
 - Fixtures reside in `tests/fixtures/` and are loaded by MSW.
 - Run tests with `bun run test`. No backend services are required.
 - Sample tests can be found under `tests/` and use Testing Library helpers.
+ - End-to-end specs live in `e2e-tests/` at the repo root and run with `bun run e2e`.
 
 Always update this `AGENTS.md` when the front-end structure or tooling changes.

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -1,4 +1,4 @@
-import { defineConfig } from 'vitest/config';
+import { defineConfig, configDefaults } from 'vitest/config';
 import { svelte } from '@sveltejs/vite-plugin-svelte';
 import { fileURLToPath } from 'url';
 import { dirname, resolve } from 'path';
@@ -6,10 +6,13 @@ import { dirname, resolve } from 'path';
 const configPath = resolve(dirname(fileURLToPath(import.meta.url)), 'svelte.config.js');
 
 export default defineConfig({
+  root: dirname(fileURLToPath(import.meta.url)),
   plugins: [svelte({ configFile: configPath })],
   test: {
     environment: 'jsdom',
     globals: true,
     setupFiles: new URL('./vitest.setup.ts', import.meta.url).pathname,
+    include: ['tests/**/*.test.ts'],
+    exclude: [...configDefaults.exclude, '../e2e-tests/**'],
   },
 });

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "build": "vite build --config frontend/vite.config.ts",
     "preview": "vite preview --config frontend/vite.config.ts",
     "test": "vitest run --config frontend/vitest.config.ts",
+    "e2e": "playwright test",
     "lint": "biome lint .",
     "apigen": "dotnet build backend/Olve.Trains.UI.Server.csproj -p:OpenApiGenerateDocuments=true && kiota generate --language TypeScript -d api/api-spec.json -o frontend/src/generated/api --class-name ApiClient --namespace-name Olve.Trains.ApiClient"
   },
@@ -18,6 +19,7 @@
     "@microsoft/kiota-serialization-json": "^1.0.0-preview.96",
     "@microsoft/kiota-serialization-multipart": "^1.0.0-preview.96",
     "@microsoft/kiota-serialization-text": "^1.0.0-preview.96",
+    "@playwright/test": "^1.53.2",
     "@sveltejs/vite-plugin-svelte": "^3.0.0",
     "@testing-library/dom": "^10.4.0",
     "@testing-library/jest-dom": "^6.6.3",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,19 @@
+import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+  webServer: [
+    {
+      command: 'bun run dev',
+      url: 'http://localhost:5173',
+      reuseExistingServer: !process.env.CI,
+    },
+    {
+      command: 'dotnet run --project backend/Olve.Trains.UI.Server.csproj',
+      url: 'http://localhost:5000',
+      reuseExistingServer: !process.env.CI,
+    },
+  ],
+  use: {
+    baseURL: 'http://localhost:5173',
+  },
+});

--- a/scripts/start-e2e.sh
+++ b/scripts/start-e2e.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+set -e
+
+bun run dev &
+DEV_PID=$!
+
+dotnet run --project backend/Olve.Trains.UI.Server.csproj &
+API_PID=$!
+
+trap 'kill $DEV_PID $API_PID' EXIT
+
+wait $DEV_PID $API_PID


### PR DESCRIPTION
## Summary
- add `@playwright/test` and new `e2e` script
- configure Playwright with web servers for frontend and backend
- provide example E2E test and helper script
- run playwright in CI
- document E2E usage and update repository guidelines

## Testing
- `bun run lint`
- `bun run test`
- `bun run e2e` *(fails: script exited with code 130)*

------
https://chatgpt.com/codex/tasks/task_e_686bcf33d46483249fd2dbb894746fdb